### PR TITLE
Update alias.go

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -27,8 +27,8 @@ type WithOption = option.Option
 var (
 	WithChroot       = option.WithChroot
 	WithSnapshot     = option.WithSnapshot
-	WithAlterter     = option.WithAlerter
-	WithNullAlterter = option.WithNullAlerter
+	WithAlerter     = option.WithAlerter
+	WithNullAlerter = option.WithNullAlerter
 	// match the existing environ variable to minimize surprises
 	WithDisableWarnings = option.WithNullAlerter
 	WithDisableTools    = option.WithDisableTools


### PR DESCRIPTION
There was an error in alias.go.
I propose to either:

- rename alterter to alerter.
or
- rename alterter to alerter.
- add the old withAlterter (for compatibility reasons) but put them deprecated.